### PR TITLE
changed http to ws

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -480,7 +480,7 @@ export function cli(args) {
     .option('server', {
       alias: 's',
       type: 'string',
-      default: 'http://localhost:4000/graphql',
+      default: 'ws://localhost:4000/graphql',
       description: 'Server to connect to'
     })
     .option('verbose', {


### PR DESCRIPTION
when running ad4m executor commands like `ad4m agent generate` I was getting the following error:
```
wesley@wesley-ubuntu:~/1_Projects/clutter$ ad4m agent generate
Generating agent
Attempting to connect to http://localhost:4000/graphql
(node:30896) UnhandledPromiseRejectionWarning: SyntaxError: The URL's protocol must be one of "ws:", "wss:", or "ws+unix:"
    at initAsClient (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/ws/lib/websocket.js:692:17)
    at new WebSocket (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/ws/lib/websocket.js:84:7)
    at SubscriptionClient.connect (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/subscriptions-transport-ws/dist/client.js:446:23)
    at new SubscriptionClient (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/subscriptions-transport-ws/dist/client.js:99:18)
    at new WebSocketLink (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/@apollo/client/link/ws/ws.cjs:17:40)
    at apolloClient (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/src/cli.js:44:13)
    at ad4mClient (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/src/cli.js:62:25)
    at agentGenerate (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/src/cli.js:223:27)
    at Object.handler (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/src/cli.js:330:27)
    at /home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/yargs/build/index.cjs:1:9052
    at j (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/yargs/build/index.cjs:1:4931)
    at M.applyMiddlewareAndGetResult (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/yargs/build/index.cjs:1:9021)
    at M.runCommand (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/yargs/build/index.cjs:1:7206)
    at Jt.[runYargsParserAndExecuteCommands] (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/yargs/build/index.cjs:1:55997)
    at Jt.parse (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/yargs/build/index.cjs:1:38250)
    at Jt.get [as argv] (/home/wesley/.nvm/versions/node/v14.17.4/lib/node_modules/@perspect3vism/ad4m-cli/node_modules/yargs/build/index.cjs:1:59486)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:30896) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:30896) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
which was fixed by running `ad4m agent generate --server ws://localhost:4000/graphql`
I changed the default server url to use ws instead of http